### PR TITLE
Add critical notepad vulnerability to timeline

### DIFF
--- a/src/data/timeline.json
+++ b/src/data/timeline.json
@@ -79,7 +79,7 @@
   {
     "id": "critical-notepad-vulnerability",
     "title": "Critical Notepad vulnerability linked to new Markdown feature",
-    "description": "The Windows 11 Notepad app, recently upgraded with AI features, now carries a high-severity flaw that exposes users to dangerous attacks. Hackers can trick Windows users into clicking a malicious link inside a Markdown file, a text-based document, opened by default by the Notepad app on most Windows systems. This would then cause Notepad to launch unverified protocols that load and execute remote files/code with the same permissions as the user. The flaw, labeled CVE-2026-20841, has a severity rating of 8.8 out of 10. While not directly caused by AI, this vulnerability highlights risks from rapid feature expansion in Notepad.",
+    "description": "The Windows 11 Notepad app, recently upgraded with AI features, now carries a high-severity flaw that exposes users to dangerous attacks. Hackers can trick Windows users into clicking a malicious link inside a Markdown file, opened by default by the Notepad app on most Windows systems. This would then cause Notepad to launch unverified protocols that load and execute remote files/code with the same permissions as the user. The vulnerability, assigned CVE-2026-20841, has a severity rating of 8.8 out of 10. While not directly caused by AI, this vulnerability highlights the risks of rapid feature expansion in established software.",
     "date": "2026-02-11",
     "sources": [
       {


### PR DESCRIPTION
Added the event about the new critical notepad vulnerability added by Microsoft's "AI-powered" feature.
Thanks for the event Michael.

Looks like:
<img width="1298" height="855" alt="image" src="https://github.com/user-attachments/assets/9880d53a-bcfb-44aa-9dd7-be3764d11d6f" />
